### PR TITLE
Added for POE Web-Search bot support

### DIFF
--- a/src/poe.ts
+++ b/src/poe.ts
@@ -27,6 +27,7 @@ const bot_names = new Set([
   "Gemini-1.5-Pro-1M",
   "DALL-E-3",
   "StableDiffusionXL",
+  "Web-Search",
 ]);
 
 async function get_responses(


### PR DESCRIPTION
This makes it can access PoE web-search bot by adding -b {"Web-Search":"Web-Search"}

<img width="1709" alt="image" src="https://github.com/user-attachments/assets/3844c68a-625c-4a3c-9d2e-f47f22e074fa">
